### PR TITLE
Feat/worker count

### DIFF
--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -92,6 +92,9 @@ class TerracottaSettings(NamedTuple):
     #: Use a process pool for band retrieval in parallel
     USE_MULTIPROCESSING: bool = True
 
+    #: Number of workers to use for multiprocessing
+    MULTIPROCESSING_WORKERS: int = 3
+
     #: Maximum number of metadata keys per POST /metadata request
     MAX_POST_METADATA_KEYS: int = 100
 
@@ -160,6 +163,7 @@ class SettingSchema(Schema):
     POSTGRESQL_PASSWORD = fields.String(allow_none=True)
 
     USE_MULTIPROCESSING = fields.Boolean()
+    MULTIPROCESSING_WORKERS = fields.Integer(validate=validate.Range(min=1))
 
     MAX_POST_METADATA_KEYS = fields.Integer(validate=validate.Range(min=1))
 

--- a/terracotta/drivers/geotiff_raster_store.py
+++ b/terracotta/drivers/geotiff_raster_store.py
@@ -36,7 +36,7 @@ def create_executor() -> Executor:
 
     try:
         # this fails on architectures without /dev/shm
-        executor = ProcessPoolExecutor(max_workers=3)
+        executor = ProcessPoolExecutor(max_workers=settings.MULTIPROCESSING_WORKERS)
     except OSError:
         # fall back to serial evaluation
         warnings.warn(


### PR DESCRIPTION
Enable setting MULTIPROCESSING_WORKERS variable to control how many workers are created.